### PR TITLE
Enable "duplicate detection"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 __pycache__
 
 /.vscode
+
+*.db
+
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 /build
 /dist
+/venv
+
+.DS_Store
+
+__pycache__
+
+/.vscode

--- a/database.py
+++ b/database.py
@@ -1,0 +1,41 @@
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.pool import StaticPool
+from db_models import Base
+import os
+
+# Database file path
+DATABASE_URL = "sqlite:///renshuu_cache.db"
+
+# Create engine with connection pooling for SQLite
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+    echo=False
+)
+
+# Enable foreign keys for SQLite
+@event.listens_for(engine, "connect")
+def set_sqlite_pragma(dbapi_conn, connection_record):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+# Create session factory
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def init_db():
+    """Initialize database by creating all tables."""
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Session:
+    """Dependency for FastAPI to get database session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+

--- a/database.py
+++ b/database.py
@@ -5,7 +5,9 @@ from db_models import Base
 import os
 
 # Database file path
-DATABASE_URL = "sqlite:///renshuu_cache.db"
+# Use DATA_DIR environment variable if set, otherwise use current directory
+DATA_DIR = os.getenv("DATA_DIR", ".")
+DATABASE_URL = f"sqlite:///{os.path.join(DATA_DIR, 'renshuu_cache.db')}"
 
 # Create engine with connection pooling for SQLite
 engine = create_engine(

--- a/db_models.py
+++ b/db_models.py
@@ -1,0 +1,45 @@
+from sqlalchemy import Column, String, Index, ForeignKey
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+
+class Word(Base):
+    __tablename__ = "words"
+
+    renshuu_id = Column(String, primary_key=True)
+    japanese = Column(String, nullable=False)
+    reading = Column(String, nullable=False)
+    jmdict_id = Column(String, nullable=True)
+
+    # Relationships
+    list_memberships = relationship("ListMembership", back_populates="word", cascade="all, delete-orphan")
+
+    # Indexes
+    __table_args__ = (
+        Index("idx_japanese_reading", "japanese", "reading"),
+        Index("idx_jmdict_id", "jmdict_id"),
+    )
+
+    def __repr__(self):
+        return f"<Word(renshuu_id={self.renshuu_id}, japanese={self.japanese}, reading={self.reading})>"
+
+
+class ListMembership(Base):
+    __tablename__ = "list_memberships"
+
+    list_id = Column(String, primary_key=True)
+    renshuu_id = Column(String, ForeignKey("words.renshuu_id", ondelete="CASCADE"), primary_key=True)
+
+    # Relationships
+    word = relationship("Word", back_populates="list_memberships")
+
+    # Indexes
+    __table_args__ = (
+        Index("idx_list_id", "list_id"),
+    )
+
+    def __repr__(self):
+        return f"<ListMembership(list_id={self.list_id}, renshuu_id={self.renshuu_id})>"
+

--- a/models.py
+++ b/models.py
@@ -1,17 +1,25 @@
 from enum import Enum
-from pydantic import BaseModel
-from typing import Literal, Any
+from pydantic import BaseModel, ConfigDict
+from typing import Literal, Any, Optional
+
+
+class CanAddNotesErrorDetail(BaseModel):
+    model_config = ConfigDict(exclude_none=True)
+    
+    canAdd: bool
+    error: Optional[str] = None
 
 
 class Action(str, Enum):
     version = "version"
     addNote = "addNote"
     canAddNotes = "canAddNotes"
+    canAddNotesWithErrorDetail = "canAddNotesWithErrorDetail"
     deckNames = "deckNames"
     modelNames = "modelNames"
     modelFieldNames = "modelFieldNames"
     storeMediaFile = "storeMediaFile"
-    #multi = "multi"
+    # multi = "multi"
 
 
 class Note(BaseModel):
@@ -37,27 +45,40 @@ class Note(BaseModel):
         else:
             return None
 
+
 class NoteParam(BaseModel):
     note: Note
 
+
 class Notes(BaseModel):
     notes: list[Note]
+
 
 class BaseRequest(BaseModel):
     action: Action
     version: Literal[2]
     key: str
 
+
 class EmptyRequest(BaseRequest):
-    action: Literal[Action.version, Action.deckNames, Action.modelNames, Action.modelFieldNames, Action.storeMediaFile]
+    action: Literal[Action.version, Action.deckNames,
+                    Action.modelNames, Action.modelFieldNames, Action.storeMediaFile]
+
 
 class AddNoteRequest(BaseRequest):
     action: Literal[Action.addNote]
     params: NoteParam
 
+
 class CanAddNotesRequest(BaseRequest):
     action: Literal[Action.canAddNotes]
     params: Notes
+
+
+class CanAddNotesWithErrorDetailRequest(BaseRequest):
+    action: Literal[Action.canAddNotesWithErrorDetail]
+    params: Notes
+
 
 class StoreMediaFile(BaseRequest):
     action: Literal[Action.storeMediaFile]

--- a/models.py
+++ b/models.py
@@ -21,6 +21,7 @@ class Action(str, Enum):
     storeMediaFile = "storeMediaFile"
     findNotes = "findNotes"
     multi = "multi"
+    guiBrowse = "guiBrowse"
 
 
 class Note(BaseModel):
@@ -63,7 +64,7 @@ class BaseRequest(BaseModel):
 
 class EmptyRequest(BaseRequest):
     action: Literal[Action.version, Action.deckNames,
-                    Action.modelNames, Action.modelFieldNames, Action.storeMediaFile]
+                    Action.modelNames, Action.modelFieldNames, Action.storeMediaFile, Action.guiBrowse]
 
 
 class AddNoteRequest(BaseRequest):

--- a/models.py
+++ b/models.py
@@ -19,6 +19,7 @@ class Action(str, Enum):
     modelNames = "modelNames"
     modelFieldNames = "modelFieldNames"
     storeMediaFile = "storeMediaFile"
+    findNotes = "findNotes"
     multi = "multi"
 
 
@@ -80,6 +81,15 @@ class CanAddNotesWithErrorDetailRequest(BaseRequest):
     params: Notes
 
 
+class FindNotesParams(BaseModel):
+    query: str
+
+
+class FindNotesRequest(BaseRequest):
+    action: Literal[Action.findNotes]
+    params: FindNotesParams
+
+
 class StoreMediaFile(BaseRequest):
     action: Literal[Action.storeMediaFile]
     params: Any
@@ -91,6 +101,7 @@ RequestUnion = Union[
     AddNoteRequest,
     CanAddNotesRequest,
     CanAddNotesWithErrorDetailRequest,
+    FindNotesRequest,
 ]
 
 # TypeAdapter for automatic validation of union types

--- a/models.py
+++ b/models.py
@@ -1,11 +1,11 @@
 from enum import Enum
-from pydantic import BaseModel, ConfigDict
-from typing import Literal, Any, Optional
+from pydantic import BaseModel, ConfigDict, TypeAdapter
+from typing import Literal, Any, Optional, Union
 
 
 class CanAddNotesErrorDetail(BaseModel):
     model_config = ConfigDict(exclude_none=True)
-    
+
     canAdd: bool
     error: Optional[str] = None
 
@@ -19,7 +19,7 @@ class Action(str, Enum):
     modelNames = "modelNames"
     modelFieldNames = "modelFieldNames"
     storeMediaFile = "storeMediaFile"
-    # multi = "multi"
+    multi = "multi"
 
 
 class Note(BaseModel):
@@ -83,3 +83,43 @@ class CanAddNotesWithErrorDetailRequest(BaseRequest):
 class StoreMediaFile(BaseRequest):
     action: Literal[Action.storeMediaFile]
     params: Any
+
+
+# Union type for all possible request types (excluding MultiRequest to avoid recursion)
+RequestUnion = Union[
+    EmptyRequest,
+    AddNoteRequest,
+    CanAddNotesRequest,
+    CanAddNotesWithErrorDetailRequest,
+]
+
+# TypeAdapter for automatic validation of union types
+_request_adapter = TypeAdapter(RequestUnion)
+
+
+class MultiActionRequest(BaseModel):
+    action: Action
+    params: Optional[Any] = None
+
+    def to_request(self, key: str) -> RequestUnion:
+        """Construct a "fake request" from a MultiActionRequest."""
+        request_data = {
+            "action": self.action,
+            "version": 2,
+            "key": key
+        }
+        if self.params is not None:
+            request_data["params"] = self.params
+
+        # Use TypeAdapter to automatically validate against the union type
+        # Pydantic will determine which request type matches and validate accordingly
+        return _request_adapter.validate_python(request_data)
+
+
+class MultiParams(BaseModel):
+    actions: list[MultiActionRequest]
+
+
+class MultiRequest(BaseRequest):
+    action: Literal[Action.multi]
+    params: MultiParams

--- a/models.py
+++ b/models.py
@@ -1,0 +1,64 @@
+from enum import Enum
+from pydantic import BaseModel
+from typing import Literal, Any
+
+
+class Action(str, Enum):
+    version = "version"
+    addNote = "addNote"
+    canAddNotes = "canAddNotes"
+    deckNames = "deckNames"
+    modelNames = "modelNames"
+    modelFieldNames = "modelFieldNames"
+    storeMediaFile = "storeMediaFile"
+    #multi = "multi"
+
+
+class Note(BaseModel):
+    fields: dict
+    deckName: str
+
+    def japanese(self):
+        return self.fields["Japanese"].split("/")[0]
+
+    def reading(self):
+        japanese = self.fields["Japanese"].split("/")
+        if japanese[-1] != "":
+            return japanese[-1]
+        else:
+            return japanese[0]
+
+    def english(self):
+        return self.fields["English"]
+
+    def jmdict(self):
+        if "jmdictId" in self.fields.keys():
+            return self.fields["jmdictId"]
+        else:
+            return None
+
+class NoteParam(BaseModel):
+    note: Note
+
+class Notes(BaseModel):
+    notes: list[Note]
+
+class BaseRequest(BaseModel):
+    action: Action
+    version: Literal[2]
+    key: str
+
+class EmptyRequest(BaseRequest):
+    action: Literal[Action.version, Action.deckNames, Action.modelNames, Action.modelFieldNames, Action.storeMediaFile]
+
+class AddNoteRequest(BaseRequest):
+    action: Literal[Action.addNote]
+    params: NoteParam
+
+class CanAddNotesRequest(BaseRequest):
+    action: Literal[Action.canAddNotes]
+    params: Notes
+
+class StoreMediaFile(BaseRequest):
+    action: Literal[Action.storeMediaFile]
+    params: Any

--- a/renshuu_api.py
+++ b/renshuu_api.py
@@ -1,0 +1,78 @@
+from models import Note
+import requests
+
+class RenshuuApi():
+    session: str
+    baseurl: str = "https://api.renshuu.org/v1/"
+    headers: dict
+
+    def __init__(self, apikey: str):
+        self.session = apikey
+        self.headers = {"Authorization": f"Bearer {apikey}"}
+
+    def japanese(self, term):
+        if term["kanji_full"] == "":
+            return [self.reading(term)]
+        return [t["term"] for t in term["aforms"]] + [term["kanji_full"]]
+
+    def reading(self, term):
+        return term["hiragana_full"]
+
+    def english(self, term):
+        return term.select(".vdict_def_block")[0].get_text().strip()
+
+    def apiError(self, response):
+        if "error" in response and response["error"]:
+            return {"result": None, "error": response["error"]}
+        else:
+            return None
+
+    def schedules(self):
+        response = requests.get(f"{self.baseurl}lists", headers=self.headers).json()
+        if (e := self.apiError(response)): return e
+
+        # get lists of groups of vocab lists
+        lists = [x for x in response["termtype_groups"] if x["termtype"] == "vocab"][0] or None
+        if not lists: return []
+
+        # list of lists in "it:groupname:title" format
+        lists = [[y["list_id"] + ":" + x["group_title"] + ":" + y["title"] for y in x["lists"]] for x in lists["groups"]]
+        # flatten list
+        lists = [x for xs in lists for x in xs]
+        return lists
+
+    def lookup(self, note: Note):
+        response = requests.get(f"{self.baseurl}word/search?value={note.japanese()}", headers = self.headers).json()
+        if (e := self.apiError(response)): return e
+
+        # compare dictionary id first
+        for t in response["words"]:
+            if note.jmdict() == t["edict_ent"]:
+                return t["id"]
+        # compare kanji+reading as fallback
+        for t in response["words"]:
+            if (self.reading(t) == note.reading() and
+                note.japanese() in self.japanese(t)):
+                return t["id"]
+
+    def canAddNote(self, note: Note):
+        return True
+
+    def addNote(self, note: Note):
+        termId = self.lookup(note)
+
+        listId = note.deckName.split(":")[0]
+
+        #if listId not in [x.split(":")[0] for x in self.schedules()]:
+        #    return
+
+        if termId is not None:
+            resp = requests.put(f"{self.baseurl}word/{termId}",
+                               headers = self.headers, json = {"list_id": listId+""})
+            if not resp.ok and resp.json()["error"] != "This term is already present in the schedule.":
+                print(resp.content)
+                content = {"result": None, "error": resp.json()["error"]}
+                return JSONResponse(content=content, status_code=status.HTTP_200_OK)
+            return 1
+        print("no match")
+        #raise HTTPException(status_code = 500, detail = "No matching entry found")

--- a/renshuu_connect.py
+++ b/renshuu_connect.py
@@ -6,152 +6,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse
 
-from enum import Enum
-from pydantic import BaseModel
-from typing import Literal, Any
-import requests
+from models import Action, EmptyRequest, AddNoteRequest, CanAddNotesRequest
+from renshuu_api import RenshuuApi
 from concurrent.futures import ProcessPoolExecutor
 from collections import deque
 import os
 import sys
 
 log = deque(maxlen=100)
-
-class Action(str, Enum):
-    version = "version"
-    addNote = "addNote"
-    canAddNotes = "canAddNotes"
-    deckNames = "deckNames"
-    modelNames = "modelNames"
-    modelFieldNames = "modelFieldNames"
-    storeMediaFile = "storeMediaFile"
-    #multi = "multi"
-
-
-class Note(BaseModel):
-    fields: dict
-    deckName: str
-
-    def japanese(self):
-        return self.fields["Japanese"].split("/")[0]
-
-    def reading(self):
-        japanese = self.fields["Japanese"].split("/")
-        if japanese[-1] != "":
-            return japanese[-1]
-        else:
-            return japanese[0]
-
-    def english(self):
-        return self.fields["English"]
-
-    def jmdict(self):
-        if "jmdictId" in self.fields.keys():
-            return self.fields["jmdictId"]
-        else:
-            return None
-
-class NoteParam(BaseModel):
-    note: Note
-
-class Notes(BaseModel):
-    notes: list[Note]
-
-class BaseRequest(BaseModel):
-    action: Action
-    version: Literal[2]
-    key: str
-
-class EmptyRequest(BaseRequest):
-    action: Literal[Action.version, Action.deckNames, Action.modelNames, Action.modelFieldNames, Action.storeMediaFile]
-
-class AddNoteRequest(BaseRequest):
-    action: Literal[Action.addNote]
-    params: NoteParam
-
-class CanAddNotesRequest(BaseRequest):
-    action: Literal[Action.canAddNotes]
-    params: Notes
-
-class StoreMediaFile(BaseRequest):
-    action: Literal[Action.storeMediaFile]
-    params: Any
-
-class RenshuuApi():
-    session: str
-    baseurl: str = "https://api.renshuu.org/v1/"
-    headers: dict
-
-    def __init__(self, apikey: str):
-        self.session = apikey
-        self.headers = {"Authorization": f"Bearer {apikey}"}
-
-    def japanese(self, term):
-        if term["kanji_full"] == "":
-            return [self.reading(term)]
-        return [t["term"] for t in term["aforms"]] + [term["kanji_full"]]
-
-    def reading(self, term):
-        return term["hiragana_full"]
-
-    def english(self, term):
-        return term.select(".vdict_def_block")[0].get_text().strip()
-
-    def apiError(self, response):
-        if "error" in response and response["error"]:
-            return {"result": None, "error": response["error"]}
-        else:
-            return None
-
-    def schedules(self):
-        response = requests.get(f"{self.baseurl}lists", headers=self.headers).json()
-        if (e := self.apiError(response)): return e
-
-        # get lists of groups of vocab lists
-        lists = [x for x in response["termtype_groups"] if x["termtype"] == "vocab"][0] or None
-        if not lists: return []
-
-        # list of lists in "it:groupname:title" format
-        lists = [[y["list_id"] + ":" + x["group_title"] + ":" + y["title"] for y in x["lists"]] for x in lists["groups"]]
-        # flatten list
-        lists = [x for xs in lists for x in xs]
-        return lists
-
-    def lookup(self, note: Note):
-        response = requests.get(f"{self.baseurl}word/search?value={note.japanese()}", headers = self.headers).json()
-        if (e := self.apiError(response)): return e
-
-        # compare dictionary id first
-        for t in response["words"]:
-            if note.jmdict() == t["edict_ent"]:
-                return t["id"]
-        # compare kanji+reading as fallback
-        for t in response["words"]:
-            if (self.reading(t) == note.reading() and
-                note.japanese() in self.japanese(t)):
-                return t["id"]
-
-    def canAddNote(self, note: Note):
-        return True
-
-    def addNote(self, note: Note):
-        termId = self.lookup(note)
-
-        listId = note.deckName.split(":")[0]
-
-        #if listId not in [x.split(":")[0] for x in self.schedules()]:
-        #    return
-
-        if termId is not None:
-            resp = requests.put(f"{self.baseurl}word/{termId}",
-                               headers = self.headers, json = {"list_id": listId+""})
-            if not resp.ok and resp.json()["error"] != "This term is already present in the schedule.":
-                print(resp.content)
-                content = {"result": None, "error": resp.json()["error"]}
-                return JSONResponse(content=content, status_code=status.HTTP_200_OK)
-            return 1
-        print("no match")
-        #raise HTTPException(status_code = 500, detail = "No matching entry found")
 
 def register_exception(app: FastAPI):
     @app.exception_handler(RequestValidationError)
@@ -171,26 +33,6 @@ class LogOutput(object):
 
 sys.stdout = LogOutput()
 sys.stderr = LogOutput()
-
-if os.name == 'nt':
-    from pystray import Icon as icon, Menu as menu, MenuItem as item
-    from PIL import Image, ImageDraw
-    import psutil
-
-    def on_clicked(icon, item):
-        icon.stop()
-        parent_pid = os.getpid()
-        parent = psutil.Process(parent_pid)
-        for child in parent.children(recursive=True):  # or parent.children() for recursive=False
-            child.kill()
-        parent.kill()
-        sys.exit(0)
-
-    icon('test', Image.open(os.path.dirname(__file__) + '/kao.png'), menu=menu(
-        item(
-            'Exit',
-            on_clicked
-            ))).run_detached()
 
 app = FastAPI()
 
@@ -252,4 +94,7 @@ async def root(request: EmptyRequest | AddNoteRequest | CanAddNotesRequest):
         return 2
 
 if __name__ == "__main__":
+    if os.name == 'nt':
+        import windows
+        windows.setup_tray_icon()
     uvicorn.run(app, port=8765, log_level="warning")

--- a/renshuu_connect.py
+++ b/renshuu_connect.py
@@ -22,7 +22,8 @@ import os
 
 
 def setup_logging():
-    log_dir = "logs"
+    # Use DATA_DIR environment variable if set, otherwise use current directory
+    log_dir = os.getenv("LOGS_DIR", "logs")
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, "renshuu_connect.log")
 
@@ -160,6 +161,8 @@ def handle_action(request: RequestUnion, service: RenshuuService) -> Any:
         return ""
     elif request.action is Action.version:
         return 2
+    elif request.action is Action.guiBrowse:
+        return []
     else:
         logger.debug(f"Unhandled action: {request.action}")
         return None

--- a/renshuu_service.py
+++ b/renshuu_service.py
@@ -1,0 +1,336 @@
+from models import Note, CanAddNotesErrorDetail
+from renshuu_api import RenshuuApi
+from db_models import Word, ListMembership
+from sqlalchemy.orm import Session
+from typing import Optional, List
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class RenshuuService:
+    """Service layer for Renshuu operations with caching and business logic."""
+    
+    def __init__(self, api: RenshuuApi, db: Session):
+        self.api = api
+        self.db = db
+
+    def _extract_japanese(self, term: dict) -> List[str]:
+        """Extract Japanese forms from API term object."""
+        if term.get("kanji_full") == "":
+            return [self._extract_reading(term)]
+        japanese_forms = [t["term"] for t in term.get("aforms", [])]
+        if term.get("kanji_full"):
+            japanese_forms.append(term["kanji_full"])
+        return japanese_forms
+
+    def _extract_reading(self, term: dict) -> str:
+        """Extract reading from API term object."""
+        return term.get("hiragana_full", "")
+
+    def _is_list_cached(self, list_id: str) -> bool:
+        """Check if we have cached any words for this list."""
+        count = self.db.query(ListMembership).filter(
+            ListMembership.list_id == list_id
+        ).count()
+        return count > 0
+
+    def _cache_word(self, word_data: dict) -> Word:
+        """Cache a word from API response into database."""
+        renshuu_id = word_data.get("id")
+        if not renshuu_id:
+            return None
+
+        renshuu_id = str(renshuu_id)
+
+        word = self.db.query(Word).filter(Word.renshuu_id == renshuu_id).first()
+        
+        if word:
+            word.japanese = word_data.get("kanji_full", "")
+            word.reading = self._extract_reading(word_data)
+            word.jmdict_id = word_data.get("edict_ent")
+        else:
+            word = Word(
+                renshuu_id=renshuu_id,
+                japanese=word_data.get("kanji_full", ""),
+                reading=self._extract_reading(word_data),
+                jmdict_id=word_data.get("edict_ent")
+            )
+            self.db.add(word)
+        
+        return word
+
+    def _cache_list_membership(self, list_id: str, renshuu_id: str):
+        """Cache a list membership, avoiding duplicates."""
+        existing = self.db.query(ListMembership).filter(
+            ListMembership.list_id == list_id,
+            ListMembership.renshuu_id == renshuu_id
+        ).first()
+        
+        if not existing:
+            membership = ListMembership(
+                list_id=list_id,
+                renshuu_id=renshuu_id
+            )
+            self.db.add(membership)
+
+    def _cache_words_from_response(self, response: dict):
+        """Proactively cache all words from API search response."""
+        if "words" not in response:
+            return
+        
+        for word_data in response["words"]:
+            self._cache_word(word_data)
+        
+        self.db.commit()
+
+    def _is_vocab_term(self, term: dict) -> bool:
+        """Check if a term from list contents is a vocab word."""
+        return (
+            "id" in term and
+            "kanji_full" in term and
+            "hiragana_full" in term and
+            "kanji" not in term and
+            "title_english" not in term and
+            "japanese" not in term
+        )
+
+    def _fetch_and_cache_list_contents(self, list_id: str):
+        """
+        Fetch all pages of a list and cache all vocab words and their memberships.
+        This is called when we first encounter a list.
+        """
+        logger.info(f"Fetching and caching list contents for list_id: {list_id}")
+        page = 1
+        nr_terms = None
+        total_pages = None
+        
+        while True:
+            response = self.api.get_list_contents(list_id, page)
+            
+            if "error" in response:
+                logger.error(f"Error fetching list {list_id} page {page}: {response.get('error')}")
+                break
+            
+            contents = response.get("contents", {})
+            terms = contents.get("terms", [])
+            
+            if page == 1:
+                nr_terms = response.get("num_terms", 0)
+                total_pages = contents.get("total_pg", 1)
+            
+            for term in terms:
+                if self._is_vocab_term(term):
+                    word = self._cache_word(term)
+                    if word:
+                        self._cache_list_membership(list_id, word.renshuu_id)
+            
+            if page >= total_pages:
+                break
+            
+            page += 1
+        
+        self.db.commit()
+        logger.info(f"Finished caching list contents for list_id: {list_id}, {total_pages} pages cached, {nr_terms} terms cached")
+
+    def lookup_word(self, note: Note) -> Optional[str]:
+        """
+        Look up a word for a note, checking cache first, then API.
+        Returns renshuu_id if found, None otherwise.
+        """
+        # Prefer jmdict_id
+        jmdict_id = note.jmdict()
+        if jmdict_id:
+            word = self.db.query(Word).filter(Word.jmdict_id == jmdict_id).first()
+            if word:
+                return word.renshuu_id
+
+        # Check cache by (japanese, reading) combination
+        japanese = note.japanese()
+        reading = note.reading()
+        word = self.db.query(Word).filter(
+            Word.japanese == japanese,
+            Word.reading == reading
+        ).first()
+        
+        if word:
+            return word.renshuu_id
+
+        response = self.api.search_words(japanese)
+        
+        if "error" in response:
+            return None
+        
+        if "words" not in response or not response["words"]:
+            return None
+
+        # Proactively cache all returned words
+        self._cache_words_from_response(response)
+
+        # Match note to word using jmdict_id
+        if jmdict_id:
+            for word_data in response["words"]:
+                if word_data.get("edict_ent") == jmdict_id:
+                    return word_data.get("id")
+
+        # Fallback: match by kanji+reading
+        for word_data in response["words"]:
+            word_reading = self._extract_reading(word_data)
+            word_japanese_forms = self._extract_japanese(word_data)
+            
+            if word_reading == reading and japanese in word_japanese_forms:
+                return word_data.get("id")
+
+        return None
+
+    def add_note(self, note: Note):
+        """
+        Add a note to a list.
+        Returns result or error dictionary.
+        """
+        term_id = self.lookup_word(note)
+        
+        if term_id is None:
+            logger.warning(f"Could not find word for note: {note.japanese()}")
+            return None
+
+        list_id = note.deckName.split(":")[0]
+        logger.debug(f"Adding note to list {list_id}, term_id: {term_id}")
+
+        # fetch and cache l its contents
+        if not self._is_list_cached(list_id):
+            self._fetch_and_cache_list_contents(list_id)
+
+        # Check cache if word is already in list
+        membership = self.db.query(ListMembership).filter(
+            ListMembership.list_id == list_id,
+            ListMembership.renshuu_id == term_id
+        ).first()
+        
+        if membership:
+            # Already in list, return success
+            logger.debug(f"Word {term_id} already in list {list_id}")
+            return 1
+
+        # Not cached, call API
+        resp = self.api.add_word_to_list(term_id, list_id)
+        
+        if not resp.ok:
+            resp_json = resp.json()
+            if resp_json.get("error") != "This term is already present in the schedule.":
+                return {"result": None, "error": resp_json.get("error")}
+
+        existing = self.db.query(ListMembership).filter(
+            ListMembership.list_id == list_id,
+            ListMembership.renshuu_id == term_id
+        ).first()
+        if not existing:
+            membership = ListMembership(
+                list_id=list_id,
+                renshuu_id=term_id
+            )
+            self.db.add(membership)
+            self.db.commit()
+        return 1
+
+    def can_add_note(self, _note: Note) -> bool:
+        # To conserve API calls we always return True
+        return True
+
+    def _lookup_word_cache_only(self, note: Note) -> Optional[str]:
+        """
+        Look up a word in cache only, without calling the API.
+        Returns renshuu_id if found in cache, None otherwise.
+        """
+        # Prefer jmdict_id
+        jmdict_id = note.jmdict()
+        if jmdict_id:
+            word = self.db.query(Word).filter(Word.jmdict_id == jmdict_id).first()
+            if word:
+                return word.renshuu_id
+
+        # Check cache by (japanese, reading) combination
+        japanese = note.japanese()
+        reading = note.reading()
+        word = self.db.query(Word).filter(
+            Word.japanese == japanese,
+            Word.reading == reading
+        ).first()
+        
+        if word:
+            return word.renshuu_id
+
+        return None
+
+    def can_add_notes_with_error_detail(self, note: Note) -> CanAddNotesErrorDetail:
+        """
+        Check if a note can be added by checking only the local cache.
+        Returns False with error detail if the term is already in the list.
+        """
+        term_id = self._lookup_word_cache_only(note)
+        
+        if term_id is not None:
+            list_id = note.deckName.split(":")[0]
+            
+            membership = self.db.query(ListMembership).filter(
+                ListMembership.list_id == list_id,
+                ListMembership.renshuu_id == term_id
+            ).first()
+            
+            if membership:
+                return CanAddNotesErrorDetail(
+                    canAdd=False,
+                    error="cannot create note because it is a duplicate"
+                )
+        
+        return CanAddNotesErrorDetail(canAdd=True, error=None)
+
+    def get_schedules(self) -> List[str]:
+        """
+        Get formatted list of schedules.
+        Returns list in "it:groupname:title" format.
+        """
+        response = self.api.get_lists()
+        
+        if "error" in response:
+            return response
+
+        termtype_groups = response.get("termtype_groups", [])
+        vocab_group = next(
+            (x for x in termtype_groups if x.get("termtype") == "vocab"),
+            None
+        )
+        
+        if not vocab_group:
+            return []
+
+        groups = vocab_group.get("groups", [])
+        formatted_lists = []
+        for group in groups:
+            group_title = group.get("group_title", "")
+            lists = group.get("lists", [])
+            for list_item in lists:
+                list_id = list_item.get("list_id", "")
+                title = list_item.get("title", "")
+                formatted_lists.append(f"{list_id}:{group_title}:{title}")
+        
+        return formatted_lists
+
+    def drop_list_cache(self, list_id: str) -> dict:
+        """
+        Drop all cached data for a specific list.
+        Deletes all ListMembership records with the given list_id.
+        Returns a dictionary with the count of deleted records.
+        """
+        count = self.db.query(ListMembership).filter(
+            ListMembership.list_id == list_id
+        ).count()
+        
+        self.db.query(ListMembership).filter(
+            ListMembership.list_id == list_id
+        ).delete()
+        
+        self.db.commit()
+        
+        return {"deleted_count": count, "list_id": list_id}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests
 fastapi
 uvicorn
+sqlalchemy ~= 2.0
 pillow; sys_platform == 'win32'
 psutil; sys_platform == 'win32'
 pystray; sys_platform == 'win32' 

--- a/windows.py
+++ b/windows.py
@@ -1,0 +1,24 @@
+import sys
+import os
+from pystray import Icon as icon, Menu as menu, MenuItem as item
+from PIL import Image, ImageDraw
+import psutil
+
+
+def on_clicked(icon, _item):
+    icon.stop()
+    parent_pid = os.getpid()
+    parent = psutil.Process(parent_pid)
+    # or parent.children() for recursive=False
+    for child in parent.children(recursive=True):
+        child.kill()
+    parent.kill()
+    sys.exit(0)
+
+
+def setup_tray_icon():
+    icon('test', Image.open(os.path.dirname(__file__) + '/kao.png'), menu=menu(
+        item(
+            'Exit',
+            on_clicked
+        ))).run_detached()


### PR DESCRIPTION
First, sorry about the huge change. I tried to break it down into smaller commits to the best of my ability. If you want I can try to split this out into multiple PRs hopefully making the review a bit easier.

I tried to get duplicate detection working correctly / show if a word is already in the list. Obviously there is the API limit, so figured making a bunch of calls to do that would be wasteful. So also added local caching with a simple SQLite database. This now has the added benefit if you have multiple (trusted) people that share the same renshuu-connect you can save on API usage. As we cache a local mapping of jmdict / japanese -> renshuuID mapping in addition to what's in each list.

The duplicate detection will only look in the local cached version of the list. There is somewhat of implied understanding that removing items from a list is not something you often do. Although I did provide a new endpoint to allow you to flush the cache of a list. Maybe we can provide a crappy web interface to allow that to be done easier.

The DB table is not crazy optimized, but hopefully will be able to support everyone's needs.

While debugging did some small improvements to the logging infrastructure, hopefully helps future debugging

Again, thank you so much for the work, I really enjoyed it so far